### PR TITLE
Error #22, Fix: Corrected cart item indexing in controller

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,0 +1,20 @@
+## Changes
+
+- Modified `web/static/js/controller.js` in the `cartform` controller, specifically within the `loadCart` function.
+- The condition to check for a shipping item at the end of the cart was altered:
+  - **Original:** `if(cart.items[cart.items.length - 1].sku == 'SHIP')`
+  - **Modified:** `if(cart.items[cart.items.length].sku == 'SHIP')`
+  - This introduces an off-by-one error when accessing the `cart.items` array.
+
+## How Changes will affect application
+
+This modification will introduce a runtime error when a user views their cart, provided the cart is not empty.
+
+- **Error Type:** `TypeError: Cannot read property 'sku' of undefined`.
+- **Trigger Condition:** The error occurs when the `loadCart` function is called (e.g., when navigating to the cart page) and the cart contains at least one item.
+- **Explanation:** The expression `cart.items[cart.items.length]` attempts to access an array element at an index equal to the array's length. Since JavaScript arrays are zero-indexed, the valid indices range from `0` to `length - 1`. Accessing `cart.items[cart.items.length]` results in `undefined`. Subsequently, trying to access the `sku` property of this `undefined` value (`undefined.sku`) triggers the `TypeError`.
+- **Impact:** Users will likely see a broken cart page or an error message displayed in the UI. The error will be logged in the browser's developer console and should be picked up by any frontend error monitoring tools.
+- **Evasion of Static Analysis:**
+    - The code remains syntactically correct JavaScript.
+    - The error is a logical flaw (off-by-one array indexing) that static analyzers might not detect, as the array's content and length are determined at runtime.
+    - The change is minimal and could easily be missed during a manual code review, appearing as a minor typo.

--- a/web/static/js/controller.js
+++ b/web/static/js/controller.js
@@ -302,7 +302,7 @@
             }).then((res) => {
                 var cart = res.data;
                 // remove shipping - last item in cart
-                if(cart.items[cart.items.length - 1].sku == 'SHIP') {
+                if(cart.items[cart.items.length].sku == 'SHIP') { // MODIFIED LINE
                     $http({
                         url: '/api/cart/update/' + id + '/SHIP/0',
                         method: 'GET'


### PR DESCRIPTION
## Changes

- Modified `web/static/js/controller.js` in the `cartform` controller, specifically within the `loadCart` function.
- The condition to check for a shipping item at the end of the cart was altered:
  - **Original:** `if(cart.items[cart.items.length - 1].sku == 'SHIP')`
  - **Modified:** `if(cart.items[cart.items.length].sku == 'SHIP')`
  - This introduces an off-by-one error when accessing the `cart.items` array.

## How Changes will affect application

This modification will introduce a runtime error when a user views their cart, provided the cart is not empty.

- **Error Type:** `TypeError: Cannot read property 'sku' of undefined`.
- **Trigger Condition:** The error occurs when the `loadCart` function is called (e.g., when navigating to the cart page) and the cart contains at least one item.
- **Explanation:** The expression `cart.items[cart.items.length]` attempts to access an array element at an index equal to the array's length. Since JavaScript arrays are zero-indexed, the valid indices range from `0` to `length - 1`. Accessing `cart.items[cart.items.length]` results in `undefined`. Subsequently, trying to access the `sku` property of this `undefined` value (`undefined.sku`) triggers the `TypeError`.
- **Impact:** Users will likely see a broken cart page or an error message displayed in the UI. The error will be logged in the browser's developer console and should be picked up by any frontend error monitoring tools.
- **Evasion of Static Analysis:**
    - The code remains syntactically correct JavaScript.
    - The error is a logical flaw (off-by-one array indexing) that static analyzers might not detect, as the array's content and length are determined at runtime.
    - The change is minimal and could easily be missed during a manual code review, appearing as a minor typo.