### PR TITLE
Error #25, Data: Update price field format for Watson product in catalogue

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,0 +1,30 @@
+## Changes
+
+- **File Modified**: `mongo/catalogue.js`
+- **Modification**: The `price` field for the product with `sku: 'Watson'` was changed from a numerical value (`2001`) to a string (`"2001"`).
+
+```diff
+// mongo/catalogue.js
+...
+db.products.insertMany([
+-    {sku: 'Watson', name: 'Watson', description: 'Probably the smartest AI on the planet', price: 2001, instock: 2, categories: ['Artificial Intelligence']},
++    {sku: 'Watson', name: 'Watson', description: 'Probably the smartest AI on the planet', price: "2001", instock: 2, categories: ['Artificial Intelligence']},
+...
+]);
+...
+```
+
+## How Changes will affect application
+
+This modification introduces a subtle data type mismatch for the price of a specific product. While this change will pass compilation, build processes, and is unlikely to be flagged by linters or static analysis tools due to JavaScript's dynamic typing and MongoDB's schema flexibility, it will cause runtime issues.
+
+When the application attempts to use the `price` of the 'Watson' product in numerical calculations (e.g., calculating the subtotal in the cart, overall cart total, taxes, or any other financial computation), the operation will involve a string instead of a number.
+
+This will likely lead to:
+1.  **`NaN` (Not a Number) Results**: Arithmetic operations (e.g., `qty * product.price`) involving the string price (`"2001"`) will result in `NaN`.
+2.  **Propagation of `NaN`**: This `NaN` value can propagate through subsequent calculations, leading to incorrect cart totals, tax amounts, and potentially affecting order processing.
+3.  **Incorrect Data Display**: The user interface might display `NaN` or an incorrect value for the price of the 'Watson' product or for totals involving this product.
+4.  **Error Logs**: Services attempting arithmetic operations with the string price will likely produce `NaN` values, which might be logged or lead to unexpected behavior. While not always a crashing error, it represents a silent data corruption that can lead to significant functional issues.
+5.  **Downstream Service Failures**: If these `NaN` values are passed to other services (e.g., payment service), they could cause errors or rejections, as these services usually expect valid numerical currency values.
+
+The error will only manifest when the 'Watson' product is interacted with in a way that utilizes its price for calculations, making it a data-dependent failure.

--- a/mongo/catalogue.js
+++ b/mongo/catalogue.js
@@ -3,7 +3,7 @@
 //
 db = db.getSiblingDB('catalogue');
 db.products.insertMany([
-    {sku: 'Watson', name: 'Watson', description: 'Probably the smartest AI on the planet', price: 2001, instock: 2, categories: ['Artificial Intelligence']},
+    {sku: 'Watson', name: 'Watson', description: 'Probably the smartest AI on the planet', price: "2001", instock: 2, categories: ['Artificial Intelligence']},
     {sku: 'Ewooid', name: 'Ewooid', description: 'Fully sentient assistant', price: 200, instock: 0, categories: ['Artificial Intelligence']},
     {sku: 'HPTD', name: 'High-Powered Travel Droid', description: 'Traveling to the far reaches of the Galaxy? You need this for protection. Comes in handy when you are lost in space', price: 1200, instock: 12, categories: ['Robot']},
     {sku: 'UHJ', name: 'Ultimate Harvesting Juggernaut', description: 'Extraterrestrial vegetation harvester', price: 5000, instock: 10, categories: ['Robot']},


### PR DESCRIPTION
## Changes

- **File Modified**: `mongo/catalogue.js`
- **Modification**: The `price` field for the product with `sku: 'Watson'` was changed from a numerical value (`2001`) to a string (`"2001"`).

```diff
// mongo/catalogue.js
...
db.products.insertMany([
-    {sku: 'Watson', name: 'Watson', description: 'Probably the smartest AI on the planet', price: 2001, instock: 2, categories: ['Artificial Intelligence']},
+    {sku: 'Watson', name: 'Watson', description: 'Probably the smartest AI on the planet', price: "2001", instock: 2, categories: ['Artificial Intelligence']},
...
]);
...
```

## How Changes will affect application

This modification introduces a subtle data type mismatch for the price of a specific product. While this change will pass compilation, build processes, and is unlikely to be flagged by linters or static analysis tools due to JavaScript's dynamic typing and MongoDB's schema flexibility, it will cause runtime issues.

When the application attempts to use the `price` of the 'Watson' product in numerical calculations (e.g., calculating the subtotal in the cart, overall cart total, taxes, or any other financial computation), the operation will involve a string instead of a number.

This will likely lead to:
1.  **`NaN` (Not a Number) Results**: Arithmetic operations (e.g., `qty * product.price`) involving the string price (`"2001"`) will result in `NaN`.
2.  **Propagation of `NaN`**: This `NaN` value can propagate through subsequent calculations, leading to incorrect cart totals, tax amounts, and potentially affecting order processing.
3.  **Incorrect Data Display**: The user interface might display `NaN` or an incorrect value for the price of the 'Watson' product or for totals involving this product.
4.  **Error Logs**: Services attempting arithmetic operations with the string price will likely produce `NaN` values, which might be logged or lead to unexpected behavior. While not always a crashing error, it represents a silent data corruption that can lead to significant functional issues.
5.  **Downstream Service Failures**: If these `NaN` values are passed to other services (e.g., payment service), they could cause errors or rejections, as these services usually expect valid numerical currency values.

The error will only manifest when the 'Watson' product is interacted with in a way that utilizes its price for calculations, making it a data-dependent failure.